### PR TITLE
updated header text, added current status section

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <header class="headerSection">
         <h2>Roller Derby</h2>
         <h1>United</h1>
-        <p>a fundraiser by toronto roller derby, for all of roller derby.</p>
+        <p>a fundraiser by ToRD skaters, for all of roller derby.</p>
         <p>#RollerDerbyUnited #TheNewEngagementZone</p>
     </header>
     <section class="welcomeSection">
@@ -61,7 +61,7 @@
     <section class="applySection">
         <div class="wrapper">
             <h2>Apply for Assistance</h2>
-            <p>Download the application below, fill it out with information from your league, and email the filled out document to rollerderbyunited@torontorollerderby.com with the subject line “RELIEF FUND APPLICATION”</p>
+            <p>Download the application below, fill it out with information from your league, and email the filled out document to rollerderbyunited@torontorollerderby.com with the subject line “RELIEF FUND APPLICATION” by May 3rd.</p>
             <p>The more money we raise, the more leagues we can help, and the more meaningful a contribution we can distribute. We encourage all leagues to share this fundraiser to your audience, so we can reach and benefit as many people as possible! We are stronger together.</p>
             <h3>Apply Now</h3>
             <button><a href="./assets/docs/rdu_covid19relieffund_application.docx" download="Roller Derby United COVID19 Relief Fund Application">Word Doc</a></button>
@@ -109,6 +109,13 @@
                     </p>
                 </li>
             </ul>
+        </div>
+    </section>
+    <!-- Used the donateSection class to reuse the stylings -->
+    <section class="donateSection">
+        <div class="wrapper">
+            <h2>Current Status</h2>
+            <p>To date, we have raised ~$1,400 in t-shirt proceeds and donations—huge thanks to all who contributed! Right now two leagues have applied for funding in addition to Toronto Roller Derby (so, a total of three applications)—and it’s looking like our fundraising goal will likely exceed $15,000.</p>
         </div>
     </section>
     <!-- <section class="sponsorsSection">


### PR DESCRIPTION
Updated header text to read "organized by ToRD skaters" instead of "by Toronto Roller Derby".  Added a 'current status' section below the FAQ, used the donate section styling. 